### PR TITLE
[PROP-2226] ADD: auto migration from the stored configuration used in previous versions

### DIFF
--- a/src/main/java/io/jenkins/plugins/propelo/job_reporter/extensions/JenkinsHeartbeatAperiodicWork.java
+++ b/src/main/java/io/jenkins/plugins/propelo/job_reporter/extensions/JenkinsHeartbeatAperiodicWork.java
@@ -14,7 +14,7 @@ import io.jenkins.plugins.propelo.commons.service.JenkinsStatusService;
 import io.jenkins.plugins.propelo.commons.service.LevelOpsPluginConfigService;
 import io.jenkins.plugins.propelo.commons.service.ProxyConfigService;
 import io.jenkins.plugins.propelo.commons.utils.JsonUtils;
-import io.jenkins.plugins.propelo.job_reporter.plugins.LevelOpsPluginImpl;
+import io.jenkins.plugins.propelo.job_reporter.plugins.PropeloPluginImpl;
 import jenkins.model.Jenkins;
 
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +31,7 @@ public class JenkinsHeartbeatAperiodicWork extends AperiodicWork {
 
     private static final Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
     private static final ObjectMapper mapper = JsonUtils.buildObjectMapper();
-    private final LevelOpsPluginImpl plugin = LevelOpsPluginImpl.getInstance();
+    private final PropeloPluginImpl plugin = PropeloPluginImpl.getInstance();
     private final LevelOpsPluginConfigService levelOpsPluginConfigService = new LevelOpsPluginConfigService();
 
     public JenkinsHeartbeatAperiodicWork() {
@@ -73,7 +73,7 @@ public class JenkinsHeartbeatAperiodicWork extends AperiodicWork {
 
     @NotNull
     public HeartbeatResponse sendHeartbeat(String hbRequestPayload, GenericRequestService genericRequestService,
-                                           LevelOpsPluginImpl plugin, final ProxyConfigService.ProxyConfig proxyConfig) throws IOException {
+                                           PropeloPluginImpl plugin, final ProxyConfigService.ProxyConfig proxyConfig) throws IOException {
         GenericResponse genericResponse = genericRequestService.performGenericRequest(plugin.getLevelOpsApiKey().getPlainText(),
                 "JenkinsHeartbeat", hbRequestPayload, plugin.isTrustAllCertificates(), null, proxyConfig);
         HeartbeatResponse heartbeatResponse = mapper.readValue(genericResponse.getPayload(),

--- a/src/main/java/io/jenkins/plugins/propelo/job_reporter/extensions/JobConfigContentChangeListener.java
+++ b/src/main/java/io/jenkins/plugins/propelo/job_reporter/extensions/JobConfigContentChangeListener.java
@@ -10,7 +10,7 @@ import io.jenkins.plugins.propelo.commons.service.JenkinsConfigSCMService;
 import io.jenkins.plugins.propelo.commons.service.JobRunParserService;
 import io.jenkins.plugins.propelo.commons.service.JobSCMStorageService;
 import io.jenkins.plugins.propelo.commons.utils.JsonUtils;
-import io.jenkins.plugins.propelo.job_reporter.plugins.LevelOpsPluginImpl;
+import io.jenkins.plugins.propelo.job_reporter.plugins.PropeloPluginImpl;
 import io.jenkins.plugins.propelo.job_reporter.service.ConfigChangeService;
 
 import org.apache.commons.lang.StringUtils;
@@ -27,7 +27,7 @@ import static java.util.logging.Level.SEVERE;
 public class JobConfigContentChangeListener extends SaveableListener {
     private static final Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
     private static final ObjectMapper mapper = JsonUtils.buildObjectMapper();
-    private final LevelOpsPluginImpl plugin = LevelOpsPluginImpl.getInstance();
+    private final PropeloPluginImpl plugin = PropeloPluginImpl.getInstance();
 
     /** {@inheritDoc} */
     @Override

--- a/src/main/java/io/jenkins/plugins/propelo/job_reporter/extensions/JobConfigStateChangeListener.java
+++ b/src/main/java/io/jenkins/plugins/propelo/job_reporter/extensions/JobConfigStateChangeListener.java
@@ -9,7 +9,7 @@ import io.jenkins.plugins.propelo.commons.service.JenkinsConfigSCMService;
 import io.jenkins.plugins.propelo.commons.service.JobRunParserService;
 import io.jenkins.plugins.propelo.commons.service.JobSCMStorageService;
 import io.jenkins.plugins.propelo.commons.utils.JsonUtils;
-import io.jenkins.plugins.propelo.job_reporter.plugins.LevelOpsPluginImpl;
+import io.jenkins.plugins.propelo.job_reporter.plugins.PropeloPluginImpl;
 import io.jenkins.plugins.propelo.job_reporter.service.ConfigChangeService;
 
 import org.apache.commons.lang.StringUtils;
@@ -25,7 +25,7 @@ import static java.util.logging.Level.FINEST;
 public class JobConfigStateChangeListener extends ItemListener {
     private static final Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
     private static final ObjectMapper mapper = JsonUtils.buildObjectMapper();
-    private final LevelOpsPluginImpl plugin = LevelOpsPluginImpl.getInstance();
+    private final PropeloPluginImpl plugin = PropeloPluginImpl.getInstance();
 
     /**
      * {@inheritDoc}

--- a/src/main/java/io/jenkins/plugins/propelo/job_reporter/extensions/LevelOpsMgmtLink.java
+++ b/src/main/java/io/jenkins/plugins/propelo/job_reporter/extensions/LevelOpsMgmtLink.java
@@ -4,7 +4,7 @@ import hudson.Extension;
 import hudson.model.Hudson;
 import hudson.model.ManagementLink;
 import hudson.util.Secret;
-import io.jenkins.plugins.propelo.job_reporter.plugins.LevelOpsPluginImpl;
+import io.jenkins.plugins.propelo.job_reporter.plugins.PropeloPluginImpl;
 import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.QueryParameter;
@@ -66,7 +66,7 @@ public class LevelOpsMgmtLink extends ManagementLink {
 
         Hudson.getInstance().checkPermission(Hudson.ADMINISTER);
 
-        final LevelOpsPluginImpl plugin = LevelOpsPluginImpl.getInstance();
+        final PropeloPluginImpl plugin = PropeloPluginImpl.getInstance();
         plugin.setLevelOpsApiKey(Secret.fromString(levelOpsApiKey));
         plugin.setLevelOpsPluginPath(levelOpsPluginPath);
         plugin.setJenkinsBaseUrl(Jenkins.get().getRootUrl());
@@ -81,8 +81,8 @@ public class LevelOpsMgmtLink extends ManagementLink {
         rsp.sendRedirect(res.getContextPath() + "/" + PLUGIN_NAME);
     }
 
-    public LevelOpsPluginImpl getConfiguration() {
-        return LevelOpsPluginImpl.getInstance();
+    public PropeloPluginImpl getConfiguration() {
+        return PropeloPluginImpl.getInstance();
     }
 
     public String getJenkinsStatus() {

--- a/src/main/java/io/jenkins/plugins/propelo/job_reporter/extensions/LevelOpsRunListener.java
+++ b/src/main/java/io/jenkins/plugins/propelo/job_reporter/extensions/LevelOpsRunListener.java
@@ -20,7 +20,7 @@ import io.jenkins.plugins.propelo.commons.service.LevelOpsPluginConfigService;
 import io.jenkins.plugins.propelo.commons.service.ProxyConfigService;
 import io.jenkins.plugins.propelo.commons.utils.DateUtils;
 import io.jenkins.plugins.propelo.commons.utils.JsonUtils;
-import io.jenkins.plugins.propelo.job_reporter.plugins.LevelOpsPluginImpl;
+import io.jenkins.plugins.propelo.job_reporter.plugins.PropeloPluginImpl;
 import io.jenkins.plugins.propelo.job_reporter.service.JobRunCodeCoverageResultsService;
 import io.jenkins.plugins.propelo.job_reporter.service.JobRunCodeCoverageXmlResultsService;
 import io.jenkins.plugins.propelo.job_reporter.service.JobRunCompleteDataService;
@@ -49,7 +49,7 @@ import static io.jenkins.plugins.propelo.commons.plugins.Common.RUN_HISTORY_COMP
 @Extension
 public class LevelOpsRunListener extends RunListener<Run> {
     private static final Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
-    private final LevelOpsPluginImpl plugin = LevelOpsPluginImpl.getInstance();
+    private final PropeloPluginImpl plugin = PropeloPluginImpl.getInstance();
     private static final ObjectMapper mapper = JsonUtils.buildObjectMapper();
     private static final ObjectMapper xmlMapper = new XmlMapper();
     private static final String JOB_SUCCESSFUL = "SUCCESS";

--- a/src/main/java/io/jenkins/plugins/propelo/job_reporter/service/ConfigChangeService.java
+++ b/src/main/java/io/jenkins/plugins/propelo/job_reporter/service/ConfigChangeService.java
@@ -15,7 +15,7 @@ import io.jenkins.plugins.propelo.commons.service.JobSCMStorageService;
 import io.jenkins.plugins.propelo.commons.service.LevelOpsPluginConfigService;
 import io.jenkins.plugins.propelo.commons.service.ProxyConfigService;
 import io.jenkins.plugins.propelo.commons.utils.MimickedUser;
-import io.jenkins.plugins.propelo.job_reporter.plugins.LevelOpsPluginImpl;
+import io.jenkins.plugins.propelo.job_reporter.plugins.PropeloPluginImpl;
 import jenkins.model.Jenkins;
 
 import java.io.File;
@@ -29,12 +29,12 @@ import static hudson.init.InitMilestone.COMPLETED;
 
 public class ConfigChangeService {
     private static final Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
-    private final LevelOpsPluginImpl plugin;
+    private final PropeloPluginImpl plugin;
     private final JobSCMStorageService jobSCMStorageService;
     private final JobRunParserService jobRunParserService;
     private final ObjectMapper mapper;
 
-    public ConfigChangeService(LevelOpsPluginImpl plugin, JobSCMStorageService jobSCMStorageService, JobRunParserService jobRunParserService, ObjectMapper mapper) {
+    public ConfigChangeService(PropeloPluginImpl plugin, JobSCMStorageService jobSCMStorageService, JobRunParserService jobRunParserService, ObjectMapper mapper) {
         this.plugin = plugin;
         this.jobSCMStorageService = jobSCMStorageService;
         this.jobRunParserService = jobRunParserService;

--- a/src/main/java/io/jenkins/plugins/propelo/job_reporter/service/JobRunCompleteDataService.java
+++ b/src/main/java/io/jenkins/plugins/propelo/job_reporter/service/JobRunCompleteDataService.java
@@ -12,7 +12,7 @@ import io.jenkins.plugins.propelo.commons.models.blue_ocean.Step;
 import io.jenkins.plugins.propelo.commons.service.BlueOceanRestClient;
 import io.jenkins.plugins.propelo.commons.service.JobFullNameConverter;
 import io.jenkins.plugins.propelo.commons.service.ProxyConfigService;
-import io.jenkins.plugins.propelo.job_reporter.plugins.LevelOpsPluginImpl;
+import io.jenkins.plugins.propelo.job_reporter.plugins.PropeloPluginImpl;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -34,11 +34,11 @@ public class JobRunCompleteDataService {
     private static final Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
     private static int MAX_RECURSION_LEVELS = 50;
 
-    private final LevelOpsPluginImpl plugin;
+    private final PropeloPluginImpl plugin;
     private final ObjectMapper mapper;
     private final ProxyConfigService.ProxyConfig proxyConfig;
 
-    public JobRunCompleteDataService(LevelOpsPluginImpl plugin, ObjectMapper mapper, final ProxyConfigService.ProxyConfig proxyConfig) {
+    public JobRunCompleteDataService(PropeloPluginImpl plugin, ObjectMapper mapper, final ProxyConfigService.ProxyConfig proxyConfig) {
         this.plugin = plugin;
         this.mapper = mapper;
         this.proxyConfig = proxyConfig;

--- a/src/main/java/io/levelops/plugins/levelops_job_reporter/plugins/LevelOpsPluginImpl.java
+++ b/src/main/java/io/levelops/plugins/levelops_job_reporter/plugins/LevelOpsPluginImpl.java
@@ -1,0 +1,297 @@
+package io.levelops.plugins.levelops_job_reporter.plugins;
+
+import hudson.XmlFile;
+import io.jenkins.plugins.propelo.commons.utils.DateUtils;
+import io.jenkins.plugins.propelo.commons.utils.EnvironmentVariableNotDefinedException;
+import io.jenkins.plugins.propelo.commons.utils.Utils;
+import jenkins.model.Jenkins;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.jenkins.plugins.propelo.commons.plugins.Common.REPORTS_DIR_NAME;
+
+public class LevelOpsPluginImpl {
+// { public void save() {}; public void load() {};} 
+// extends Plugin {
+    private static final Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
+    private static final String DATA_DIR_NAME = "run-complete-data";
+    public static final String PLUGIN_SHORT_NAME = "propelo-job-reporter";
+    private String levelOpsApiKey = "";
+    private String levelOpsPluginPath = "${JENKINS_HOME}/levelops-jenkin";
+    private boolean trustAllCertificates = false;
+    private String productIds = "";
+    private String jenkinsInstanceName = "Jenkins Instance";
+    public Boolean isRegistered = false;
+    private String jenkinsStatus = "";
+    private String jenkinsUserName = "";
+    private String jenkinsBaseUrl = "";
+    private String jenkinsUserToken = "";
+    private long heartbeatDuration = 60;
+    private String bullseyeXmlResultPaths = "";
+    private long configUpdatedAt = System.currentTimeMillis();
+    private static LevelOpsPluginImpl instance = null;
+    private static final Pattern OLDER_DIRECTORIES_PATTERN = Pattern.compile("^(run-complete-data-)");
+    private Boolean migrated = false;
+
+    //ToDo: This is deprecated! Fix soon.
+    private LevelOpsPluginImpl() {
+    }
+
+    private XmlFile getConfig() {
+        File configFile = new File(Jenkins.get().getRootDir(),"levelops-job-reporter.xml");
+        LOGGER.info("LevelOpsPluginImpl config path: " + configFile.getAbsolutePath());
+        return new XmlFile(Jenkins.XSTREAM, configFile);
+    }
+    
+    public void load() throws IOException{
+        XmlFile xml = getConfig();
+        if (xml.exists()){
+            xml.unmarshal(this);
+        }
+    }
+
+    public void save() throws IOException {
+        XmlFile xml = getConfig();
+        xml.write(this);
+    }
+
+    public static LevelOpsPluginImpl getInstance() {
+        if (LevelOpsPluginImpl.instance == null) {
+            LevelOpsPluginImpl.instance = new LevelOpsPluginImpl();
+        }
+        return LevelOpsPluginImpl.instance;
+    }
+
+    public void setMigrated(boolean migrated) {
+        this.migrated = migrated;
+    }
+
+    public boolean isMigrated(){
+        return this.migrated != null ? this.migrated : false;
+    }
+
+    public File getHudsonHome() {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        return (jenkins == null) ? null : jenkins.getRootDir();
+    }
+
+    public void setJenkinsBaseUrl(final String jenkinsBaseUrl){
+        this.jenkinsBaseUrl = jenkinsBaseUrl;
+    }
+
+    public String getJenkinsBaseUrl(){
+        return this.jenkinsBaseUrl;
+    }
+
+    public String getLevelOpsApiKey() {
+        return levelOpsApiKey;
+    }
+
+    public void setLevelOpsApiKey(String levelOpsApiKey) {
+        this.levelOpsApiKey = levelOpsApiKey;
+    }
+
+    /**
+     * Get the Propelo plugin path as entered by the user. May contain environment variables.
+     *
+     * If you need a path that can be used as is (env. vars expanded), please use @link{getExpandedLevelOpsPluginPath}.
+     *
+     * @return the path as entered by the user.
+     */
+    public String getLevelOpsPluginPath() {
+        return levelOpsPluginPath;
+    }
+
+    public void setLevelOpsPluginPath(String levelOpsPluginPath) {
+        this.levelOpsPluginPath = levelOpsPluginPath;
+    }
+
+    /**
+     * @return the levelOpsPluginPath path with possibly contained environment variables expanded.
+     */
+    public String getExpandedLevelOpsPluginPath() {
+        if (StringUtils.isBlank(levelOpsPluginPath)) {
+            return levelOpsPluginPath;
+        }
+        String expandedPath = "";
+        try {
+            expandedPath = Utils.expandEnvironmentVariables(levelOpsPluginPath);
+        } catch (final EnvironmentVariableNotDefinedException evnde) {
+            LOGGER.log(Level.SEVERE, evnde.getMessage() + " Using unexpanded path.");
+            expandedPath = levelOpsPluginPath;
+        }
+
+        return expandedPath;
+    }
+
+    public String getJenkinsStatus() {
+        return jenkinsStatus;
+    }
+
+    public void setJenkinsStatus(String jenkinsStatus) {
+        this.jenkinsStatus = jenkinsStatus;
+    }
+
+    public long getConfigUpdatedAt() {
+        return configUpdatedAt;
+    }
+
+    public void setConfigUpdatedAt(long configUpdatedAt) {
+        this.configUpdatedAt = configUpdatedAt;
+    }
+
+    public long getHeartbeatDuration() {
+        return heartbeatDuration;
+    }
+
+    public void setHeartbeatDuration(long heartbeatDuration) {
+        this.heartbeatDuration = heartbeatDuration;
+    }
+
+    public File getExpandedLevelOpsPluginDir() {
+        return new File(this.getExpandedLevelOpsPluginPath());
+    }
+
+
+    public Boolean isRegistered() {
+        return isRegistered;
+    }
+
+    public boolean isExpandedLevelOpsPluginPathNullOrEmpty(){
+        return StringUtils.isEmpty(getExpandedLevelOpsPluginPath());
+    }
+
+    private File buildReportsDirectory(String levelOpsPluginPath){
+        return new File(levelOpsPluginPath,REPORTS_DIR_NAME);
+    }
+    public File getReportsDirectory() {
+        return buildReportsDirectory(this.getExpandedLevelOpsPluginPath());
+    }
+
+    private void deleteOlderDirectories() {
+        File currentDataDirectoryWithVersion = getDataDirectoryWithVersion();
+        File expandedLevelOpsPluginDir = getExpandedLevelOpsPluginDir();
+        if (expandedLevelOpsPluginDir != null && expandedLevelOpsPluginDir.exists()
+                && currentDataDirectoryWithVersion != null) {
+            for (File file : Objects.requireNonNull(expandedLevelOpsPluginDir.listFiles())) {
+                Matcher matcher = OLDER_DIRECTORIES_PATTERN.matcher(file.getName());
+                if (matcher.find() && !file.getName().equalsIgnoreCase(currentDataDirectoryWithVersion.getName())) {
+                    FileUtils.deleteQuietly(file);
+                }
+            }
+        }
+    }
+
+    public String getPluginVersionString() {
+        LOGGER.log(Level.FINEST, "getPluginVersionString starting");
+        String pluginVersionString = Jenkins.get().getPluginManager().getPlugin(LevelOpsPluginImpl.PLUGIN_SHORT_NAME).getVersion();
+        LOGGER.log(Level.FINEST, "getPluginVersionString completed pluginVersionString = {0}", pluginVersionString);
+        return pluginVersionString;
+    }
+
+    private File buildDataDirectory(String levelOpsPluginPath) {
+        LOGGER.log(Level.FINEST, "buildDataDirectory starting");
+        File dataDirectory = new File(levelOpsPluginPath, DATA_DIR_NAME);
+        LOGGER.log(Level.FINEST, "buildDataDirectory completed = {0}", dataDirectory);
+        return dataDirectory;
+    }
+    public File getDataDirectory() {
+        return buildDataDirectory(this.getExpandedLevelOpsPluginPath());
+    }
+
+    private File buildDataDirectoryWithVersion(String levelOpsPluginPath) {
+        LOGGER.log(Level.FINEST, "buildDataDirectoryWithVersion starting");
+        String dataDirWithVersionName = DATA_DIR_NAME + "-" + getPluginVersionString();
+        LOGGER.log(Level.FINEST, "dataDirWithVersionName = {0}", dataDirWithVersionName);
+        File dataDirectoryWithVersion = new File(levelOpsPluginPath, dataDirWithVersionName);
+        LOGGER.log(Level.FINEST, "buildDataDirectoryWithVersion completed = {0}", dataDirectoryWithVersion);
+        return dataDirectoryWithVersion;
+    }
+    public File getDataDirectoryWithVersion() {
+        return buildDataDirectoryWithVersion(this.getExpandedLevelOpsPluginPath());
+    }
+
+    public File getDataDirectoryWithRotation() {
+        File dataDirWithVersion = buildDataDirectoryWithVersion(this.getExpandedLevelOpsPluginPath());
+        LOGGER.log(Level.FINEST, "dataDirWithVersion = {0}", dataDirWithVersion);
+        File dataDirWithRotation = new File(dataDirWithVersion, DateUtils.getDateFormattedDirName());
+        LOGGER.log(Level.FINEST, "dataDirWithRotation = {0}", dataDirWithRotation);
+        return dataDirWithRotation;
+    }
+
+    public String getJenkinsUserName() {
+        return jenkinsUserName;
+    }
+
+    public void setJenkinsUserName(String jenkinsUserName) {
+        this.jenkinsUserName = jenkinsUserName;
+    }
+
+    public String getJenkinsUserToken() {
+        return jenkinsUserToken;
+    }
+
+    public void setJenkinsUserToken(String jenkinsUserToken) {
+        this.jenkinsUserToken = jenkinsUserToken;
+    }
+
+    public String getBullseyeXmlResultPaths() {
+        return bullseyeXmlResultPaths;
+    }
+
+    public void setBullseyeXmlResultPath(String bullseyeXmlResultPaths) {
+        this.bullseyeXmlResultPaths = bullseyeXmlResultPaths;
+    }
+
+    public boolean isTrustAllCertificates() {
+        return trustAllCertificates;
+    }
+
+    public void setTrustAllCertificates(boolean trustAllCertificates) {
+        this.trustAllCertificates = trustAllCertificates;
+    }
+
+    public String getProductIds() {
+        return productIds;
+    }
+
+    public void setProductIds(String productIds) {
+        this.productIds = productIds;
+    }
+
+    private List<String> parseProductIdsList(String productIds){
+        if((productIds == null) || (productIds.length() == 0)){
+            return Collections.emptyList();
+        }
+        String[] productIdsSplit = productIds.split(",");
+        if((productIdsSplit == null) || (productIdsSplit.length ==0)){
+            return Collections.emptyList();
+        }
+        return Arrays.asList(productIdsSplit);
+    }
+    public List<String> getProductIdsList(){
+        return parseProductIdsList(this.productIds);
+    }
+
+    public String getJenkinsInstanceName() {
+        return jenkinsInstanceName;
+    }
+
+    public void setJenkinsInstanceName(String jenkinsInstanceName) {
+        this.jenkinsInstanceName = jenkinsInstanceName;
+    }
+
+}


### PR DESCRIPTION
For users of the old levelops-job-reporter plugin that are migrating to the new propelo-job-reporter plugin, the previously stored configurations will be auto-migrated to the new plugin.