### PR TITLE
[PROP-2199] Fix: NoSuchMethod in JobRunParserService causing some jobs not to be reported

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     </profiles>
 
     <properties>
-        <revision>1.0.22</revision>
+        <revision>1.0.23</revision>
         <!-- <changelist>999999-SNAPSHOT</changelist> -->
         <changelist></changelist>
         <product.build.sourceEncoding>UTF-8</product.build.sourceEncoding>

--- a/src/main/java/io/jenkins/plugins/propelo/commons/service/JobRunParserService.java
+++ b/src/main/java/io/jenkins/plugins/propelo/commons/service/JobRunParserService.java
@@ -13,6 +13,8 @@ import io.jenkins.plugins.propelo.commons.models.JobRunDetail;
 import io.jenkins.plugins.propelo.commons.models.JobRunParam;
 import io.jenkins.plugins.propelo.commons.models.JobTrigger;
 import jenkins.model.Jenkins;
+
+import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 
 import java.io.File;
@@ -236,11 +238,11 @@ public class JobRunParserService {
             case "UserIdCause":
                 Cause.UserIdCause userIdCause = (Cause.UserIdCause) cause;
                 LOGGER.finest("JobRunParserService::getUserCauseUser currentUser = " + userIdCause.getUserId());
-                return Objects.firstNonNull(userIdCause.getUserId(), ACL.ANONYMOUS_USERNAME);
+                return (String) ObjectUtils.defaultIfNull(userIdCause.getUserId(), ACL.ANONYMOUS_USERNAME);
             case "UserCause":
                 Cause.UserCause userCause = (Cause.UserCause) cause;
                 LOGGER.finest("JobRunParserService::getUserCauseUser currentUser = " + userCause.getUserName());
-                return Objects.firstNonNull(userCause.getUserName(), ACL.ANONYMOUS_USERNAME);
+                return (String) ObjectUtils.defaultIfNull(userCause.getUserName(), ACL.ANONYMOUS_USERNAME);
             default:
                 LOGGER.finest("JobRunParserService::getUserCauseUser currentUser = " + ACL.SYSTEM_USERNAME);
                 return ACL.SYSTEM_USERNAME;
@@ -310,6 +312,8 @@ public class JobRunParserService {
             case "RemoteCause":
                 triggerId = ((Cause.RemoteCause) cause).getAddr();
                 break;
+            case "GitHubPushCause":
+                LOGGER.info("GitHubPushCause, handling it as the SCMTriggerCause");
             case "SCMTriggerCause":
                 triggerId = "SCMTrigger";
                 break;


### PR DESCRIPTION
[PROP-2199] Fix: related to missing method in dependency
ADD: Using SCMTrigger id for GitHubPushCause

`java.lang.NoSuchMethodError: 'java.lang.Object com.google.common.base.Objects.firstNonNull(java.lang.Object, java.lang.Object)'
	at io.levelops.plugins.commons.service.JobRunParserService.getUserCauseUser(JobRunParserService.java:239)
	at io.levelops.plugins.commons.service.JobRunParserService.buildTriggerChain(JobRunParserService.java:308)
	at io.levelops.plugins.commons.service.JobRunParserService.buildTriggerChain(JobRunParserService.java:330)
	at io.levelops.plugins.commons.service.JobRunParserService.parseJobRun(JobRunParserService.java:277)
	at io.levelops.plugins.levelops_job_reporter.extensions.LevelOpsRunListener.onFinalized(LevelOpsRunListener.java:142)
	at hudson.model.listeners.RunListener.lambda$fireFinalized$3(RunListener.java:244)
	at jenkins.util.Listeners.lambda$notify$0(Listeners.java:59)
	at jenkins.util.Listeners.notify(Listeners.java:67)
	at hudson.model.listeners.RunListener.fireFinalized(RunListener.java:242)
	at hudson.model.Run.onEndBuilding(Run.java:2062)
	at hudson.model.Run.execute(Run.java:1969)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:44)
	at hudson.model.ResourceController.execute(ResourceController.java:107)
	at hudson.model.Executor.run(Executor.java:449)`