### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 8],
+    [platform: 'windows', jdk: 8],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>4.13.2</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.jsoup/jsoup -->

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
This PR removes the deprecated recommendedConfigurations syntax to favor a proper configuration.
Internally, recommendedConfigurations does no longer apply any configuration it used to apply years ago.

Additionally, this PR addresses a regression from https://github.com/jenkinsci/propelo-job-reporter-plugin/pull/10

I'll expedite the merge, once the infrastructure changes to ci.jenkins.io have been merged into production, to prevent failing builds on the default branch and new pull requests.