### PR TITLE
SEI-2499 - Jenkins Plugin - Causing "Too many open files" on Jenkins Server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     </profiles>
 
     <properties>
-        <revision>1.0.28</revision>
+        <revision>1.0.29</revision>
         <!-- <changelist>999999-SNAPSHOT</changelist> -->
         <changelist></changelist>
         <product.build.sourceEncoding>UTF-8</product.build.sourceEncoding>

--- a/src/main/java/io/jenkins/plugins/propelo/commons/service/JobLogsService.java
+++ b/src/main/java/io/jenkins/plugins/propelo/commons/service/JobLogsService.java
@@ -25,7 +25,21 @@ public class JobLogsService {
         File failedJobLogFile = getPathToLogFile(run.getParent().getRootDir().toString(), run.getNumber()).toFile();
         StringBuilder logsFromFile = new StringBuilder();
         String lineFromFile;
-        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(failedJobLogFile))) {
+        /*
+        https://stackoverflow.com/questions/884007/correct-way-to-close-nested-streams-and-writers-in-java
+        Good:
+        try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(f))) {
+          // do something with ois
+        }
+        Better:
+        try (FileInputStream fis = new FileInputStream(f); ObjectInputStream ois = new ObjectInputStream(fis)) {
+          // do something with ois
+        }
+        Reason: The try-with-resources is not aware of the inner FileInputStream, so if the ObjectInputStream constructor throws an exception,
+        the FileInputStream is never closed (until the garbage collector gets to it).
+         */
+        try ( FileReader fr = new FileReader(failedJobLogFile);
+              BufferedReader bufferedReader = new BufferedReader(fr)) {
             while ((lineFromFile = bufferedReader.readLine()) != null) {
                 logsFromFile.append(lineFromFile);
                 logsFromFile.append(separator);

--- a/src/main/java/io/jenkins/plugins/propelo/commons/service/JobRunPerforceChangesParserService.java
+++ b/src/main/java/io/jenkins/plugins/propelo/commons/service/JobRunPerforceChangesParserService.java
@@ -50,7 +50,22 @@ public class JobRunPerforceChangesParserService {
 
     private String getInputStreamAsString(InputStream inputStream) throws IOException {
         StringBuilder stringBuilder = new StringBuilder();
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
+
+        /*
+        https://stackoverflow.com/questions/884007/correct-way-to-close-nested-streams-and-writers-in-java
+        Good:
+        try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(f))) {
+          // do something with ois
+        }
+        Better:
+        try (FileInputStream fis = new FileInputStream(f); ObjectInputStream ois = new ObjectInputStream(fis)) {
+          // do something with ois
+        }
+        Reason: The try-with-resources is not aware of the inner FileInputStream, so if the ObjectInputStream constructor throws an exception,
+        the FileInputStream is never closed (until the garbage collector gets to it).
+         */
+        try ( InputStreamReader isr = new InputStreamReader(inputStream);
+              BufferedReader br = new BufferedReader(isr) ) {
             String line;
             while ((line = br.readLine()) != null) {
                 stringBuilder.append(line);


### PR DESCRIPTION
As part of Plugin version 1.0.28, there was a fix added for, PROP-3540 - issue removing too many old report files from a jenkins instance.
This new code opened java stream (linux file) and did not close them. This caused the linux "Too many open files" error.
This error was reproducible in version 1.0.28. The fix was verified in dev environment.
Also added defensive code at other places where stream is opened.
